### PR TITLE
fix removeFromArray

### DIFF
--- a/src/ngAnimate/shared.js
+++ b/src/ngAnimate/shared.js
@@ -118,7 +118,7 @@ function pendClasses(classes, fix, isPrefix) {
 
 function removeFromArray(arr, val) {
   var index = arr.indexOf(val);
-  if (val >= 0) {
+  if (index >= 0) {
     arr.splice(index, 1);
   }
 }


### PR DESCRIPTION
removeFromArray check if `val >= 0` before `arr.splice(index, 1)`, instead of `index >= 0`